### PR TITLE
Fix optimizer bug: weight decay missing.

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -144,7 +144,7 @@ def train(model, train_set, valid_set, test_set, save, train_size=0, valid_size=
         batch_size=batch_size,
     )
     criterion = nn.CrossEntropyLoss()
-    optimizer = optim.SGD(model.parameters(), lr=lr, momentum=momentum, nesterov=True)
+    optimizer = optim.SGD(model.parameters(), lr=lr, momentum=momentum, nesterov=True, weight_decay=wd)
 
     # Wrap model if multiple gpus
     if torch.cuda.device_count() > 1:


### PR DESCRIPTION
Cann't reproduce densenet performance on cifar10. The reason is because weight decay option is missing in SGD optimizer.