### PR TITLE
use adaptive_avg_pool2d instead of avg_pool2d

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# vscode project settings
+.vscode

--- a/demo.py
+++ b/demo.py
@@ -157,7 +157,6 @@ def train(model, train_set, valid_set, test_set, save, n_epochs=300,
     # Train model
     best_error = 1
     for epoch in range(n_epochs):
-        scheduler.step()
         _, train_loss, train_error = train_epoch(
             model=model_wrapper,
             loader=train_loader,
@@ -165,6 +164,7 @@ def train(model, train_set, valid_set, test_set, save, n_epochs=300,
             epoch=epoch,
             n_epochs=n_epochs,
         )
+        scheduler.step()
         _, valid_loss, valid_error = test_epoch(
             model=model_wrapper,
             loader=valid_loader if valid_loader else test_loader,

--- a/models/densenet.py
+++ b/models/densenet.py
@@ -95,7 +95,6 @@ class DenseNet(nn.Module):
 
         super(DenseNet, self).__init__()
         assert 0 < compression <= 1, 'compression of densenet should be between 0 and 1'
-        self.avgpool_size = 8 if small_inputs else 7
 
         # First convolution
         if small_inputs:
@@ -151,6 +150,7 @@ class DenseNet(nn.Module):
     def forward(self, x):
         features = self.features(x)
         out = F.relu(features, inplace=True)
-        out = F.avg_pool2d(out, kernel_size=self.avgpool_size).view(features.size(0), -1)
+        out = F.adaptive_avg_pool2d(out, (1, 1))
+        out = torch.flatten(out, 1)
         out = self.classifier(out)
         return out


### PR DESCRIPTION
Closes #56 
removed `self.avgpool_size` as no longer needed.
moved `scheduler.step()` below `train_epoch` to remove pytorch warning "UserWarning: Detected call of `lr_scheduler.step()` before `optimizer.step()`" when using pytorch version > 1.1.0.