### PR TITLE
Fixed number of parameters for DenseNet-BC

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -263,11 +263,16 @@ def demo(data, save, depth=100, growth_rate=12, efficient=True, valid_size=5000,
     model = DenseNet(
         growth_rate=growth_rate,
         block_config=block_config,
+        num_init_features=growth_rate*2,
         num_classes=10,
         small_inputs=True,
         efficient=efficient,
     )
     print(model)
+    
+    # Print number of parameters
+    num_params = sum(p.numel() for p in model.parameters())
+    print("Total parameters: ", num_params)
 
     # Make save directory
     if not os.path.exists(save):


### PR DESCRIPTION
When using your implementation, I noticed that the number of parameters doesn't match the original paper when used with DenseNet-BC_250_24 and DenseNet-BC_190_40, only DenseNet-BC_100_12 matches. This modification changes the first convolutional output channels to twice the growth rate so that the number of parameters matches those in the paper.